### PR TITLE
feat: add coverage value cov subcommand

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 .packages
 build/
 pubspec.lock
+
+# Coverage
+coverage/

--- a/lib/src/cov/cov.dart
+++ b/lib/src/cov/cov.dart
@@ -1,5 +1,6 @@
 import 'package:args/command_runner.dart';
 import 'package:cov_utils/src/cov/filter/filter.dart';
+import 'package:cov_utils/src/cov/value/value.dart';
 
 /// The command invocation function that provides coverage-related
 /// functionalities.
@@ -8,7 +9,7 @@ Future<void> cov(List<String> args) async {
     'cov',
     'A set of commands that encapsulate coverage-related functionalities.',
   ) //
-    ..addCommand(FilterCommand());
-
+    ..addCommand(FilterCommand())
+    ..addCommand(ValueCommand());
   await runner.run(args);
 }

--- a/lib/src/cov/filter/filter.dart
+++ b/lib/src/cov/filter/filter.dart
@@ -13,7 +13,7 @@ class FilterCommand extends Command<void> {
     argParser
       ..addMultiOption(
         _ignorePatternsOption,
-        abbr: 'i',
+        abbr: _ignorePatternsOption[0],
         help: '''
 Set of comma-separated path patterns of the files to be ignored.
 Consider that the coverage info of each file is checked as a multiline block.
@@ -23,14 +23,14 @@ Each bloc starts with `${Prefix.sourceFile}` and ends with `${Prefix.endOfRecord
       )
       ..addOption(
         _originOption,
-        abbr: 'o',
+        abbr: _originOption[0],
         help: 'Origin coverage info file to pick coverage data from.',
         defaultsTo: 'coverage/lcov.info',
         valueHelp: _originHelpValue,
       )
       ..addOption(
         _destinationOption,
-        abbr: 'd',
+        abbr: _destinationOption[0],
         help: '''
 Destination coverage info file to dump the resulting coverage data into.''',
         defaultsTo: 'coverage/wiped.lcov.info',
@@ -57,7 +57,7 @@ The coverage data is taken from the $_originHelpValue file and the result is app
   String get name => 'filter';
 
   @override
-  List<String> get aliases => ['f'];
+  List<String> get aliases => [name[0]];
 
   @override
   Future<void> run() async {

--- a/lib/src/cov/prefix.dart
+++ b/lib/src/cov/prefix.dart
@@ -7,4 +7,10 @@ abstract class Prefix {
 
   /// A source file path.
   static const sourceFile = 'SF:';
+
+  /// The quantity of testable lines in the file.
+  static const linesFound = 'LF:';
+
+  /// The quantity of tested lines in the file.
+  static const linesHit = 'LH:';
 }

--- a/lib/src/cov/value/value.dart
+++ b/lib/src/cov/value/value.dart
@@ -87,7 +87,12 @@ Compute the coverage value of the $_fileHelpValue info file.''';
         stdout
           ..writeln(fileCoverage.sourceFile)
           ..write(fileCoverage.coveragePercentage.toStringAsFixed(2))
-          ..writeln(' %');
+          ..write(' % (')
+          ..write(fileCoverage.linesHit)
+          ..write(' of ')
+          ..write(fileCoverage.linesFound)
+          ..writeln(' lines)')
+          ..writeln();
       }
     }
 
@@ -96,6 +101,10 @@ Compute the coverage value of the $_fileHelpValue info file.''';
     stdout
       ..write('Global: ')
       ..write(resultingCoveragePercentage.toStringAsFixed(2))
-      ..write(' %');
+      ..write(' % (')
+      ..write(totalLinesHit)
+      ..write(' of ')
+      ..write(totalLinesFound)
+      ..write(' lines)');
   }
 }

--- a/lib/src/cov/value/value.dart
+++ b/lib/src/cov/value/value.dart
@@ -1,0 +1,101 @@
+import 'dart:io';
+
+import 'package:args/command_runner.dart';
+import 'package:cov_utils/src/cov/prefix.dart';
+import 'package:cov_utils/src/entities/file_coverage.dart';
+
+/// {@template value_cmd}
+/// A command to compute the coverage of a given info file.
+/// {@endtemplate filter_cmd}
+class ValueCommand extends Command<void> {
+  /// {@template filter_cmd}
+  ValueCommand() {
+    argParser
+      ..addOption(
+        _fileOption,
+        abbr: _fileOption[0],
+        help: '''
+Coverage info file to be used for the coverage value computation.''',
+        valueHelp: _fileHelpValue,
+        defaultsTo: 'coverage/lcov.info',
+      )
+      ..addFlag(
+        _printFilesFlag,
+        abbr: _printFilesFlag[0],
+        help: '''
+Print coverage value for each source file listed in the $_fileHelpValue info file.''',
+        defaultsTo: true,
+      );
+  }
+
+  static const _fileHelpValue = 'LCOV_FILE';
+
+  static const _fileOption = 'file';
+  static const _printFilesFlag = 'print-files';
+
+  @override
+  String get description => '''
+Compute the coverage value (%) of an info file.
+
+Compute the coverage value of the $_fileHelpValue info file.''';
+
+  @override
+  String get name => 'value';
+
+  @override
+  List<String> get aliases => [name[0]];
+
+  @override
+  Future<void> run() async {
+    // Retrieve arguments and validate their value and the state they represent.
+    final _argResults = ArgumentError.checkNotNull(argResults);
+
+    final filePath = ArgumentError.checkNotNull(
+      _argResults[_fileOption],
+    ) as String;
+    final shouldPrintFiles = ArgumentError.checkNotNull(
+      _argResults[_printFilesFlag],
+    ) as bool;
+
+    final file = File(filePath);
+
+    if (!file.existsSync()) {
+      throw StateError('The `$filePath` file does not exist.');
+    }
+
+    // Get coverage info.
+    final fileContent = file.readAsStringSync().trim();
+
+    // Split coverage data by the end of record prefix, which indirectly splits
+    // the info by file.
+    final filesCovData = fileContent //
+        .split(Prefix.endOfRecord) //
+        .map((s) => s.trim()) //
+        .where((s) => s.isNotEmpty);
+
+    // Set initial values.
+    var totalLinesFound = 0;
+    var totalLinesHit = 0;
+
+    // For each file coverage data.
+    for (final fileCovData in filesCovData) {
+      // Parse file coverage data.
+      final fileCoverage = FileCoverage.parse(fileCovData);
+      totalLinesFound += fileCoverage.linesFound;
+      totalLinesHit += fileCoverage.linesHit;
+      if (shouldPrintFiles) {
+        stdout
+          ..writeln(fileCoverage.sourceFile)
+          ..write(fileCoverage.coveragePercentage.toStringAsFixed(2))
+          ..writeln(' %');
+      }
+    }
+
+    // Show resulting coverage.
+    final resultingCoveragePercentage = (totalLinesHit * 100) / totalLinesFound;
+    stdout
+      ..write('Global: ')
+      ..write(resultingCoveragePercentage.toStringAsFixed(2))
+      ..write(' %');
+  }
+}

--- a/lib/src/entities/file_coverage.dart
+++ b/lib/src/entities/file_coverage.dart
@@ -1,0 +1,62 @@
+import 'package:cov_utils/src/cov/prefix.dart';
+
+/// {@template file_coverage}
+/// A file coverage data abstraction.
+/// {@endtemplate}
+class FileCoverage {
+  /// {@macro file_coverage}
+  const FileCoverage({
+    required this.sourceFile,
+    required this.linesFound,
+    required this.linesHit,
+  });
+
+  /// Create a file coverage data abstraction from a file coverage data string.
+  factory FileCoverage.parse(String fileCovDataString) {
+    final fileCovDataLines = fileCovDataString.split('\n');
+
+    final sourceFile = fileCovDataLines._strValue(Prefix.sourceFile);
+    final linesFound = fileCovDataLines._intValue(Prefix.linesFound);
+    final linesHit = fileCovDataLines._intValue(Prefix.linesHit);
+
+    return FileCoverage(
+      sourceFile: sourceFile,
+      linesFound: linesFound,
+      linesHit: linesHit,
+    );
+  }
+
+  /// Source file.
+  final String sourceFile;
+
+  /// Testable lines of code found in the [sourceFile].
+  final int linesFound;
+
+  /// Tested lines of code in the [sourceFile].
+  final int linesHit;
+
+  /// Coverage percentage for the [sourceFile].
+  double get coveragePercentage => (linesHit * 100) / linesFound;
+
+  @override
+  String toString() => '''
+FileCoverage
+  ${Prefix.sourceFile} $sourceFile
+  ${Prefix.linesFound} $linesFound
+  ${Prefix.linesHit} $linesHit''';
+}
+
+extension _FileCovDataLines on List<String> {
+  String _strValue(String key) =>
+      // Find line with the value.
+      firstWhere(
+        (l) => l.contains(key),
+        orElse: () => key,
+      )
+          // Remove key.
+          .replaceAll(key, '')
+          // Remove trailing and leading spaces.
+          .trim();
+
+  int _intValue(String key) => int.tryParse(_strValue(key)) ?? 0;
+}


### PR DESCRIPTION
## Description

- Create `value` subcommand under `cov` command to compute and console print coverage percentage.
- Show global coverage value.
- Show individual file coverage value.

## Related issues

None.