### PR TITLE
fix: print error msg only

### DIFF
--- a/bin/cov.dart
+++ b/bin/cov.dart
@@ -1,3 +1,10 @@
+import 'dart:io';
+
 import 'package:cov_utils/cov_utils.dart' show cov;
 
-Future<void> main(List<String> arguments) async => cov(arguments);
+Future<void> main(List<String> arguments) async => cov(arguments).catchError(
+      (Object e) {
+        stdout.write(e);
+        exit(1);
+      },
+    );

--- a/bin/x.dart
+++ b/bin/x.dart
@@ -1,3 +1,10 @@
+import 'dart:io';
+
 import 'package:cov_utils/cov_utils.dart' show x;
 
-Future<void> main(List<String> arguments) async => x(arguments);
+Future<void> main(List<String> arguments) async => x(arguments).catchError(
+      (Object e) {
+        stdout.write(e);
+        exit(1);
+      },
+    );


### PR DESCRIPTION
## Description

- Avoid logging stack trace on error occurrence by printing the error message only.

## Related issues

None.