### PR TITLE
refactor: use file instead of raw path

### DIFF
--- a/lib/src/commands/cov/filter/filter.dart
+++ b/lib/src/commands/cov/filter/filter.dart
@@ -96,7 +96,7 @@ The coverage data is taken from the $_originHelpValue file and the result is app
       final shouldBeIgnored = ignorePatterns.any(
         (ignorePattern) {
           final regexp = RegExp(ignorePattern);
-          return regexp.hasMatch(fileCovData.sourceFile);
+          return regexp.hasMatch(fileCovData.sourceFile.path);
         },
       );
 

--- a/lib/src/entities/source_file_cov_data.dart
+++ b/lib/src/entities/source_file_cov_data.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:meta/meta.dart';
 
 /// {@template source_file_cov_data}
@@ -140,7 +142,7 @@ class SourceFileCovData {
 
     return SourceFileCovData(
       raw: fileCovDataContent,
-      sourceFile: sourceFile,
+      sourceFile: File(sourceFile),
       linesFound: linesFound,
       linesHit: linesHit,
     );
@@ -149,8 +151,8 @@ class SourceFileCovData {
   /// Raw string representation of the [sourceFile] coverage data.
   final String raw;
 
-  /// Source file path.
-  final String sourceFile;
+  /// Source file.
+  final File sourceFile;
 
   /// Number of testable lines in the [sourceFile].
   final int linesFound;

--- a/test/src/entities/source_file_cov_data_test.dart
+++ b/test/src/entities/source_file_cov_data_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:cov_utils/src/entities/source_file_cov_data.dart';
 import 'package:test/test.dart';
 
@@ -27,7 +29,7 @@ ${SourceFileCovData.endOfRecordTag}''';
   );
   final sourceFileCovData = SourceFileCovData(
     raw: rawSourceFileCovData,
-    sourceFile: sourceFile,
+    sourceFile: File(sourceFile),
     linesFound: linesFound,
     linesHit: linesHit,
   );
@@ -44,7 +46,7 @@ THEN a positive result should be returned
       // ARRANGE
       final sameSourceFileCovData = SourceFileCovData(
         raw: rawSourceFileCovData,
-        sourceFile: sourceFile,
+        sourceFile: File(sourceFile),
         linesFound: linesFound,
         linesHit: linesHit,
       );

--- a/test/src/entities/tracefile_test.dart
+++ b/test/src/entities/tracefile_test.dart
@@ -1,4 +1,5 @@
 import 'dart:collection';
+import 'dart:io';
 
 import 'package:collection/collection.dart';
 import 'package:cov_utils/src/entities/source_file_cov_data.dart';
@@ -18,7 +19,7 @@ ${SourceFileCovData.endOfRecordTag}''';
         sourceFilesCount,
         (idx) => SourceFileCovData(
           raw: buildSourceFilesCovDataString(idx),
-          sourceFile: buildSourceFile(idx),
+          sourceFile: File(buildSourceFile(idx)),
           linesFound: idx + 1,
           linesHit: idx,
         ),


### PR DESCRIPTION
## Description

- Use file instance for source file instead of a raw path string.

## Related issues

None.